### PR TITLE
Improve handling of mouse events.

### DIFF
--- a/app/mouse.ts
+++ b/app/mouse.ts
@@ -2,51 +2,103 @@ import {canvas} from 'app/gameConstants'
 import {state} from 'app/state';
 import {isPointInCircle} from 'app/utils/geometry';
 
-let isMouseDownOnCanvas = false;
+let isMouseDownOnCanvas = false, lastMouseDownPosition: Point, lastMouseUpPosition: Point;
+let lastMousePosition: Point = {x: 0, y: 0};
 
 export function registerMouseEventHandlers() {
     // This event is fired as soon as the mouse button is pressed over the canvas.
     canvas.addEventListener('mousedown', (event: MouseEvent) => {
         isMouseDownOnCanvas = true;
-        setMovementTarget(state, event);
+        lastMousePosition = getMousePosition(event, canvas, 3);
+        lastMouseDownPosition = lastMousePosition;
     });
 
     document.addEventListener('mouseup', (event: MouseEvent) => {
         isMouseDownOnCanvas = false;
+        lastMousePosition = getMousePosition(event, canvas, 3);
+        lastMouseUpPosition = lastMousePosition;
     });
 
     canvas.addEventListener('mousemove', (event: MouseEvent) => {
-        // Don't do anything if the mouse wasn't pressed over the canvas.
-        if (!isMouseDownOnCanvas) {
-            return;
-        }
-        setMovementTarget(state, event);
+        lastMousePosition = getMousePosition(event, canvas, 3);
     });
+}
 
-
-    canvas.onclick =  function (event: MouseEvent) {
-        const worldTarget = convertToWorldPosition(getMousePosition(event, canvas, 3));
-        // Check if the user has clicked on an object.
-        for (const object of state.world.objects) {
-            if (object.objectType !== 'enemy' && object.objectType !== 'spawner') {
-                continue;
-            }
-            // Did they click on this object?
-            if (!isPointInCircle(object, worldTarget)) {
-                continue;
-            }
-            state.hero.attackTarget = object;
-            delete state.hero.target;
-            return;
+// Returns the highest priority mouse target under the given screen point.
+function getTargetAtScreenPoint(state: GameState, screenPoint: Point): MouseTarget {
+    const worldPoint = convertToWorldPosition(screenPoint);
+    for (const object of state.world.objects) {
+        if (object.objectType !== 'enemy' && object.objectType !== 'spawner') {
+            continue;
         }
-        // If not attack target was found, set a movement target.
-        delete state.hero.attackTarget;
-        state.hero.target = worldTarget;
+        if (isPointInCircle(object, worldPoint)) {
+            return object;
+        }
     }
 }
 
-function setMovementTarget(state: GameState, event: MouseEvent) {
-    const worldTarget = convertToWorldPosition(getMousePosition(event, canvas, 3));
+export function updateMouseActions(state: GameState) {
+    state.mouse.currentPosition = lastMousePosition;
+    // Trigger a click any time lastMouseUpPosition has been set since the last time we updated.
+    if (lastMouseUpPosition) {
+        // If state.mouse.mouseDownPosition was set assume the click started at this position.
+        // We definitely want to use this value if the user has released the mouse and pressed
+        // again since the last update, in which the new press should have no bearing on the
+        // click action, and this also works well enough for all other cases with additional
+        // presses+releases as we only process a maximum of one click action per frame.
+        const downPoint = state.mouse.mouseDownPosition
+            || lastMouseDownPosition
+            || lastMousePosition;
+        handleMouseClick(state, downPoint, lastMouseUpPosition);
+    }
+    // Make sure that state.mouse.mouseDownPosition and state.mouse.mouseDownTarget
+    // are set consistently with the current state of the mouse and the mose recent position
+    // that we recorded a mouse down event on the canvas.
+    if (isMouseDownOnCanvas) {
+        const previousMouseDownPosition = state.mouse.mouseDownPosition;
+        state.mouse.mouseDownPosition = lastMouseDownPosition
+            || state.mouse.mouseDownPosition
+            || lastMousePosition;
+        // Update state.mouse.mouseDownTarget any time state.mouse.mouseDownPosition is changed.
+        if (previousMouseDownPosition !== state.mouse.mouseDownPosition) {
+            state.mouse.mouseDownTarget = getTargetAtScreenPoint(state, state.mouse.mouseDownPosition);
+        }
+    } else {
+        delete state.mouse.mouseDownPosition;
+        delete state.mouse.mouseDownTarget;
+    }
+    // Delete these values to track that they have been processed.
+    lastMouseUpPosition = undefined;
+    lastMouseDownPosition = undefined;
+
+    // If the user clicks anywhere on the world that has no mouse target and holds,
+    // they will set the movement target to the current mouse position every frame.
+    if (state.mouse.mouseDownPosition && !state.mouse.mouseDownTarget) {
+        setMovementTarget(state, state.mouse.currentPosition);
+    }
+}
+function handleMouseClick(state: GameState, down: Point, up: Point) {
+    const worldDownPoint = convertToWorldPosition(down);
+    const worldUpPoint = convertToWorldPosition(up);
+    // Check if the user has clicked on an object by checking if the object
+    // intersects both with where the user pressed and released the mouse.
+    for (const object of state.world.objects) {
+        if (object.objectType !== 'enemy' && object.objectType !== 'spawner') {
+            continue;
+        }
+        // Did they click on this object?
+        if (!isPointInCircle(object, worldDownPoint) || ! isPointInCircle(object, worldUpPoint)) {
+            continue;
+        }
+        // Currently the only supported action is attacking an attackable target.
+        state.hero.attackTarget = object;
+        delete state.hero.target;
+        return;
+    }
+}
+
+function setMovementTarget(state: GameState, mousePosition: Point) {
+    const worldTarget = convertToWorldPosition(mousePosition);
     delete state.hero.attackTarget;
     state.hero.target = worldTarget;
 }
@@ -58,7 +110,7 @@ function convertToWorldPosition(canvasPoint: Point): Point {
     }
 }
 
-export function getMousePosition(event: MouseEvent, container: HTMLElement = null, scale = 1): Point {
+function getMousePosition(event: MouseEvent, container: HTMLElement = null, scale = 1): Point {
     if (container) {
         const containerRect:DOMRect = container.getBoundingClientRect();
         return {

--- a/app/mouse.ts
+++ b/app/mouse.ts
@@ -28,9 +28,6 @@ export function registerMouseEventHandlers() {
 function getTargetAtScreenPoint(state: GameState, screenPoint: Point): MouseTarget {
     const worldPoint = convertToWorldPosition(screenPoint);
     for (const object of state.world.objects) {
-        if (object.objectType !== 'enemy' && object.objectType !== 'spawner') {
-            continue;
-        }
         if (isPointInCircle(object, worldPoint)) {
             return object;
         }

--- a/app/state.ts
+++ b/app/state.ts
@@ -8,5 +8,8 @@ export const state: GameState = {
         time: 1000,
         camera: {x: 0, y: 0},
         objects: [nexus, hero, snakeSpawner],
-    }
+    },
+    mouse: {
+        currentPosition: {x: 0, y: 0},
+    },
 };

--- a/app/types/state.d.ts
+++ b/app/types/state.d.ts
@@ -36,6 +36,11 @@ interface Hero extends Circle {
 interface GameState {
     hero: Hero
     world: World
+    mouse: {
+        currentPosition: Point
+        mouseDownPosition?: Point
+        mouseDownTarget?: MouseTarget
+    }
 }
 
 interface World {
@@ -59,6 +64,9 @@ type EnemyTarget = Enemy | Spawner;
 
 
 type AttackTarget = AllyTarget | EnemyTarget;
+
+// This will eventually include clickable targets like buttons or interactive objects.
+type MouseTarget = AttackTarget;
 
 type EnemyType = 'snake';
 

--- a/app/update.ts
+++ b/app/update.ts
@@ -1,7 +1,9 @@
 import {canvas, frameLength} from 'app/gameConstants'
 import {state} from 'app/state';
+import {updateMouseActions} from 'app/mouse';
 
 function update() {
+    updateMouseActions(state);
     for (const object of state.world.objects) {
         object.update(state);
     }


### PR DESCRIPTION
It is now slightly easier to click on targets: clicks will count as long as the press+release events are over where the enemy is when the release is processed.

Click and hold to move will now apply every frame even if you do not move the mouse.

Click and hold to move will now only apply if the press did not occur on an object.

The game will now only process up to a single click event per frame. Since the game runs at 50 updates a second, this is unlikely to make much observable difference, but could effect the games behavior if it happens to lag.

While this is an improvement, it is still a bit difficult to click on an enemy that is moving quickly. If the enemy moves away from the position the mouse was pressed on, the click will not count. This could be improved by applying the click to the target the mouse was under when the press happened provided that the mouse was released close to where it was pressed even if the target has moved from where the mouse press occurred. 

Another option is to apply enemy targeting logic on mouse press and only require full clicks for stationary targets like buttons or HUD elements.