### PR TITLE
Logic added for handling destroyed nexus

### DIFF
--- a/app/objects/nexus.ts
+++ b/app/objects/nexus.ts
@@ -1,4 +1,4 @@
-import {fillCircle, renderLifeBar} from 'app/utils/draw';
+import {fillCircle, renderGameStatus, renderLifeBar} from 'app/utils/draw';
 
 export const nexus: Nexus = {
     objectType: 'nexus',
@@ -13,6 +13,10 @@ export const nexus: Nexus = {
     render(this: Nexus, context: CanvasRenderingContext2D, state: GameState) {
         fillCircle(context, this);
         renderLifeBar(context, this, this.health, this.maxHealth);
+        if (this.health <= 0){
+            renderGameStatus(context, "nexus destroyed!");
+        }
+      
     },
     update(state: GameState) {
     },

--- a/app/update.ts
+++ b/app/update.ts
@@ -1,4 +1,4 @@
-import {canvas, frameLength} from 'app/gameConstants'
+import {canvas, context, frameLength} from 'app/gameConstants'
 import {state} from 'app/state';
 import {updateMouseActions} from 'app/mouse';
 
@@ -6,6 +6,17 @@ function update() {
     updateMouseActions(state);
     for (const object of state.world.objects) {
         object.update(state);
+        
+        // If the nexus is destroyed, stop update function
+        // Pan world.camera to nexus, change background color (gray) and return.
+        if (object.objectType === "nexus" && object.health <= 0){
+            console.log("nexus dead!!!");
+            context.fillStyle = '#525046';
+            state.world.camera.x = object.x - canvas.width / 2;
+            state.world.camera.y = object.y - canvas.height / 2;
+            return;
+        }
+        
     }
     // Move the camera so the hero is in the center of the screen:
     state.world.camera.x = state.hero.x - canvas.width / 2;

--- a/app/update.ts
+++ b/app/update.ts
@@ -10,13 +10,10 @@ function update() {
         // If the nexus is destroyed, stop update function
         // Pan world.camera to nexus, change background color (gray) and return.
         if (object.objectType === "nexus" && object.health <= 0){
-            console.log("nexus dead!!!");
-            context.fillStyle = '#525046';
             state.world.camera.x = object.x - canvas.width / 2;
             state.world.camera.y = object.y - canvas.height / 2;
             return;
         }
-        
     }
     // Move the camera so the hero is in the center of the screen:
     state.world.camera.x = state.hero.x - canvas.width / 2;

--- a/app/utils/combat.ts
+++ b/app/utils/combat.ts
@@ -10,8 +10,5 @@ export function damageTarget(state: GameState, target: AttackTarget, damage: num
         if (objectIndex >= 0) {
             state.world.objects.splice(objectIndex, 1);
         }
-   
-        
-        
     }
 }

--- a/app/utils/combat.ts
+++ b/app/utils/combat.ts
@@ -4,11 +4,14 @@ export function damageTarget(state: GameState, target: AttackTarget, damage: num
         return
     }
     target.health = Math.max(0, target.health - damage);
-    if (target.health <= 0) {
-        // remove the object from the state when it dies.
+    if (target.health <= 0 && target.objectType !== 'nexus') {
+        // remove the object from the state, if not a 'nexus' when it dies.
         const objectIndex = state.world.objects.indexOf(target);
         if (objectIndex >= 0) {
             state.world.objects.splice(objectIndex, 1);
         }
+   
+        
+        
     }
 }

--- a/app/utils/draw.ts
+++ b/app/utils/draw.ts
@@ -33,3 +33,9 @@ export function renderLifeBar(context: CanvasRenderingContext2D, circle: Circle,
         w: bar.w * health / maxHealth,
     }, health >= maxHealth / 2 ? '#080' : '#F80');
 }
+
+export function renderGameStatus(context: CanvasRenderingContext2D, message: string) {
+    context.font = "20px serif";
+    context.fillStyle = '#8B0000';
+    context.fillText(message, -25, -50);
+}


### PR DESCRIPTION
Initial logic added to address the following tasks in [Issue #2 ](https://github.com/lancehalberd/minmaxer/issues/2)

combat.ts 
- Don't remove the nexus from the world objects when its health reaches 0.

update.ts
- Stop regular updates to the scene
- Pan camera back to the nexus
- change background to gray

nexus.ts will have a check on its health status and calls a renderGameStatus function in draw.ts that will display a text banner.
- text "Nexus Destroyed"

canvas backgound and text currently just updates and displays... not "fade" into effect :/
